### PR TITLE
ci: switch to the Hyperledger secrets in the GitHub actions

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -19,16 +19,16 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:  
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
-          token: ${{ secrets.ATALA_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
           
       - name: Update submodules
         run: |
           git submodule update --remote --recursive
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 16
       - name: Install dependencies

--- a/.github/workflows/delete_old_packages.yml
+++ b/.github/workflows/delete_old_packages.yml
@@ -1,8 +1,8 @@
 name: Cleanup Package Versions
 
 # This workflow is executed every Monday at 3:00 AM and deletes outdated versions of packages for the current repository.
-# Github Action actions/delete-package-versions@v4 is used.
-# Curent renention policy:
+# GitHub Action actions/delete-package-versions@v4 is used.
+# Current retention policy:
 # - Keep 10 last packages
 
 on:
@@ -10,14 +10,17 @@ on:
   schedule:
     - cron: "0 3 * * 1"
 
+permissions:
+  packages: write
+
 jobs:
   cleanup:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/delete-package-versions@v4
         with:
-          owner: input-output-hk
+          owner: ${{ github.repository_owner }}
           package-name: identus-documentation-portal
           package-type: container
           min-versions-to-keep: 10
-          token: ${{ secrets.ATALA_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -25,6 +25,9 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: read & write
+
 jobs:
   trigger-deployment:
     runs-on: ubuntu-latest
@@ -43,9 +46,9 @@ jobs:
             echo "ENV=staging" >> "${GITHUB_OUTPUT}"
           fi
       - name: Trigger deployment
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ secrets.ATALA_GITHUB_TOKEN }}
+          token: ${{ secrets.ATALA_GITHUB_TOKEN }} # Personal access token that triggers the deployment (Hyperledger => IOG)
           repository: input-output-hk/atala-prism-non-prod-argocd-state
           event-type: trigger-prism-documentation-deployment
           client-payload: '{"version": "${{ steps.parse-params.outputs.VERSION }}", "env": "${{ steps.parse-params.outputs.ENV }}"}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,39 +7,45 @@ on:
 jobs:
   release:
     env:
-      GITHUB_ACTOR: ${{ secrets.ATALA_GITHUB_ACTOR }}
-      GITHUB_TOKEN: ${{ secrets.ATALA_GITHUB_TOKEN }}
-      ATALA_GITHUB_TOKEN: ${{ secrets.ATALA_GITHUB_TOKEN }}
+      GITHUB_ACTOR: "hyperledger-bot"
+      GITHUB_ACTOR_EMAIL: "hyperledger-bot@hyperledger.org"
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
-          token: ${{ secrets.ATALA_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.event.inputs.release-branch }}
           fetch-depth: 0
-          
+
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
+
       - uses: crazy-max/ghaction-import-gpg@v5
         id: import_gpg
         with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          git_user_signingkey: true
-          git_commit_gpgsign: true
+          gpg-private-key: ${{ secrets.HYP_BOT_GPG_PRIVATE }}
+          passphrase: ${{ secrets.HYP_BOT_GPG_PASSWORD }}
+          git-user-signingkey: true
+          git-commit-gpgsign: true
+          git_config_global: true
+          git_tag_gpgsign: true
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ secrets.ATALA_GITHUB_ACTOR }}
-          password: ${{ secrets.ATALA_GITHUB_TOKEN }}
+          username: ${{ secrets.GITHUB_ACTOR }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build ADRs
         run: |
-          cd ./atala-prism-building-blocks
+          cd ./atala-prism-building-blocks 
           npm install -g log4brains
           log4brains build --out ../static/adrs --basePath /adrs
           touch ../static/adrs/.nojekyll
@@ -49,6 +55,7 @@ jobs:
           GIT_COMMITTER_EMAIL: ${{ steps.import_gpg.outputs.email }}
           GIT_AUTHOR_NAME: ${{ steps.import_gpg.outputs.name }}
           GIT_COMMITTER_NAME: ${{ steps.import_gpg.outputs.name }}
+          GITHUB_TOKEN: ${{ secrets.IDENTUS_CI }}
         run: |
           npm install
           npx semantic-release

--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -17,25 +17,33 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          token: ${{ secrets.ATALA_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           submodules: true
           fetch-depth: 0
+
       - name: Update submodules
         run: |
           git pull --recurse-submodules
           git submodule update --remote --recursive
+
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v3
+        uses: crazy-max/ghaction-import-gpg@v5
         id: import_gpg
         with:
-          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-private-key: ${{ secrets.HYP_BOT_GPG_PRIVATE }}
+          passphrase: ${{ secrets.HYP_BOT_GPG_PASSWORD }}
           git-user-signingkey: true
           git-commit-gpgsign: true
+          git_config_global: true
+
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
+          github_token: ${{ secrets.IDENTUS_CI }}
           commit_message: "feat: update submodules documentation to latest"
           commit_user_name: ${{ steps.import_gpg.outputs.name }}
           commit_user_email: ${{ steps.import_gpg.outputs.email }}
+          commit_signoff: true
+          commit_gpg_sign: true

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ brew install yarn
 
 # Create new projects directory
 cd ~ && mkdir projects && cd projects
-git clone https://github.com/input-output-hk/atala-prism-docs.git
+git clone https://github.com/hyperledger/identus-docs.git
 # Initialize submodules
 git submodule init
 # Update submodules
@@ -59,7 +59,7 @@ git submodule update --remote --recursive
 # git checkout feature-branch
 
 # Deploy local version of the website
-cd atala-prism-docs
+cd identus-docs
 yarn install
 yarn start
 ```
@@ -76,5 +76,6 @@ This command starts a local development server and opens up a browser window. Mo
 
 ```
 $ yarn build --out-dir infra/website
+```
 
 This command creates a set of static resources which can be hosted to serve the full site.

--- a/infra/release-docs-container.sh
+++ b/infra/release-docs-container.sh
@@ -4,5 +4,5 @@ VERSION="${1}"
 
 cd "$(dirname "${BASH_SOURCE[0]}")/.." || exit 126
 yarn build --out-dir infra/website
-docker build -t ghcr.io/input-output-hk/identus-documentation-portal:${VERSION} -f infra/Dockerfile .
-docker push ghcr.io/input-output-hk/identus-documentation-portal:${VERSION}
+docker build -t ghcr.io/hyperledger/identus-documentation-portal:${VERSION} -f infra/Dockerfile .
+docker push ghcr.io/hyperledger/identus-documentation-portal:${VERSION}


### PR DESCRIPTION
The PR contains the following changes:
- replace ATALA_GITHUB_TOKEN whenever it's possible
- switch from `atala-dev` bot to `hyperledger-bot`
- update GPG keys to sign the commits
- upgrade the GitHub actions to newer versions
- IDENTUS_CI token is added to the repository, but should be tested